### PR TITLE
Fixes for DM-3898: compiler warnings with clang

### DIFF
--- a/src/XrdSsi/XrdSsiResponder.hh
+++ b/src/XrdSsi/XrdSsiResponder.hh
@@ -174,6 +174,7 @@ inline Status  SetMetadata(const char *buff, int blen)
                           {SSI_VAL_RESPONSE(rP);
                            rP->Resp.mdata = buff; rP->Resp.mdlen = blen;
                            rP->reqMutex.UnLock();
+                           return wasPosted;
                           }
 
 //-----------------------------------------------------------------------------

--- a/src/XrdSsi/XrdSsiSession.hh
+++ b/src/XrdSsi/XrdSsiSession.hh
@@ -42,7 +42,7 @@
 //-----------------------------------------------------------------------------
 
 class XrdSsiRequest;
-class XrdSsiRespInfo;
+struct XrdSsiRespInfo;
 class XrdSsiTask;
 
 class XrdSsiSession


### PR DESCRIPTION
Address some warnings generated by clang
