### PR TITLE
libXrdSsi-4.dylib needs libXrdUtils to link properly on OSX

### DIFF
--- a/src/XrdPlugins.cmake
+++ b/src/XrdPlugins.cmake
@@ -120,6 +120,7 @@ add_library(
 target_link_libraries(
   ${LIB_XRD_SSI}
   XrdSsiLib
+  XrdUtils
   XrdServer )
 
 set_target_properties(


### PR DESCRIPTION
This one line change fixes the build on OS X. It looks like it should be applied to the `xrdssi` upstream branch first but I don't know enough about how Xrootd works to the best approach. I'll leave it up to @fritzm to decide the best course of action.
